### PR TITLE
Update Rank Events

### DIFF
--- a/src/Module/Rank/RankEvents.cs
+++ b/src/Module/Rank/RankEvents.cs
@@ -398,7 +398,6 @@ namespace K4System
 									break;
 								}
 							// Grenade impact kill (hitting a player and killing them with a grenade when they are 1hp for example)
-							// No idea how bump mines work, but I kept them here anyways.
 							case var _ when lowerCaseWeaponName.Contains("grenade") || lowerCaseWeaponName.Contains("molotov") || lowerCaseWeaponName.Contains("flashbang") || lowerCaseWeaponName.Contains("bumpmine"):
 								{
 									ModifyPlayerPoints(killer, Config.PointSettings.ImpactKill, "k4.phrases.impactkill");

--- a/src/Module/Rank/RankEvents.cs
+++ b/src/Module/Rank/RankEvents.cs
@@ -385,12 +385,27 @@ namespace K4System
 
 						switch (lowerCaseWeaponName)
 						{
-							case var _ when lowerCaseWeaponName.Contains("grenade") || lowerCaseWeaponName.Contains("firebomb") || lowerCaseWeaponName.Contains("molotov") || lowerCaseWeaponName.Contains("flashbang") || lowerCaseWeaponName.Contains("bumpmine"):
+							//Killed by grenade explosion
+							case var _ when lowerCaseWeaponName.Contains("hegrenade"):
 								{
 									ModifyPlayerPoints(killer, Config.PointSettings.GrenadeKill, "k4.phrases.grenadekill");
 									break;
 								}
-							case var _ when lowerCaseWeaponName.Contains("knife_") || lowerCaseWeaponName.Contains("bayonet"):
+							//Molotov or Incendiary fire kill
+							case var _ when lowerCaseWeaponName.Contains("inferno"):
+								{
+									ModifyPlayerPoints(killer, Config.PointSettings.InfernoKill, "k4.phrases.infernokill");
+									break;
+								}
+							// Grenade impact kill (hitting a player and killing them with a grenade when they are 1hp for example)
+							// No idea how bump mines work, but I kept them here anyways.
+							case var _ when lowerCaseWeaponName.Contains("grenade") || lowerCaseWeaponName.Contains("molotov") || lowerCaseWeaponName.Contains("flashbang") || lowerCaseWeaponName.Contains("bumpmine"):
+								{
+									ModifyPlayerPoints(killer, Config.PointSettings.ImpactKill, "k4.phrases.impactkill");
+									break;
+								}
+							// knife_ would not handle default knives (therefore changed to just "knife"), this will also not handle other Danger Zone items such as axes and wrenches (if they are even implemented yet in CS2)
+							case var _ when lowerCaseWeaponName.Contains("knife") || lowerCaseWeaponName.Contains("bayonet"):
 								{
 									ModifyPlayerPoints(killer, Config.PointSettings.KnifeKill, "k4.phrases.knifekill");
 									break;

--- a/src/Plugin/PluginConfig.cs
+++ b/src/Plugin/PluginConfig.cs
@@ -300,6 +300,12 @@ namespace K4System
 		[JsonPropertyName("grenade-kill")]
 		public int GrenadeKill { get; set; } = 30;
 
+		[JsonPropertyName("inferno-kill")]
+		public int InfernoKill { get; set; } = 30;
+
+		[JsonPropertyName("impact-kill")]
+		public int ImpactKill { get; set; } = 100;
+
 		[JsonPropertyName("taser-kill")]
 		public int TaserKill { get; set; } = 20;
 

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -85,6 +85,8 @@
   "k4.phrases.blindkill": "Blind Kill",
   "k4.phrases.longdistance": "Long Distance",
   "k4.phrases.grenadekill": "Grenade Kill",
+  "k4.phrases.infernokill": "Fire Kill",
+  "k4.phrases.impactkill": "Impact Kill",
   "k4.phrases.knifekill": "Knife Kill",
   "k4.phrases.taserkill": "Taser Kill",
   "k4.phrases.doublekill": "Double Kill",


### PR DESCRIPTION
RankEvents.cs:
Not handling default knives properly
Separated HE grenade (explosion and impact) event to grenade kill
Added inferno (fire) kill from molotov
Added impact kill (1hp kill from direct hit by grenade for example)

Please review the added default score gain values and adjust to your liking. Grenade impact kills are very rare in normal play and this is why I made it so high.

Added plugin phrases also need to be added in language translations (if merged)