### PR TITLE
Restrict top to top 50 and fix negative and 0 top usage

### DIFF
--- a/src/Module/Rank/RankCommands.cs
+++ b/src/Module/Rank/RankCommands.cs
@@ -125,7 +125,7 @@ namespace K4System
 
 					if (int.TryParse(info.ArgByIndex(1), out int parsedInt))
 					{
-						printCount = parsedInt;
+						printCount = Math.Min(50, parsedInt);
 					}
 
 					CCSPlayerController savedPlayer = player;

--- a/src/Module/Rank/RankCommands.cs
+++ b/src/Module/Rank/RankCommands.cs
@@ -125,7 +125,7 @@ namespace K4System
 
 					if (int.TryParse(info.ArgByIndex(1), out int parsedInt))
 					{
-						printCount = Math.Min(50, parsedInt);
+						printCount = Math.Max(1, Math.Min(50, parsedInt));
 					}
 
 					CCSPlayerController savedPlayer = player;


### PR DESCRIPTION
At high database counts this presents a performance concern when querying for thousands of entries