### PR TITLE
Add penalties for team-kill assists and team-flash-assists (BUG #211)

### DIFF
--- a/K4-System/src/Module/Rank/RankEvents.cs
+++ b/K4-System/src/Module/Rank/RankEvents.cs
@@ -251,7 +251,7 @@ namespace K4System
 					}
 					else
 					{
-						
+
 						RankData k4attackerRankData = k4attacker.rankData;
 						if (Config.RankSettings.PointsForBots || k4attacker.IsPlayer)
 						{
@@ -270,9 +270,12 @@ namespace K4System
 					else
 					{
 						string? extraInfo;
-						if (k4attacker.IsPlayer && k4victimRankData != null) {
+						if (k4attacker.IsPlayer && k4victimRankData != null)
+						{
 							extraInfo = Config.RankSettings.PlayerNameKillMessages ? plugin.Localizer["k4.phrases.kill.extra", k4victim.PlayerName, k4victimRankData.Points] : null!;
-						} else {
+						}
+						else
+						{
 							extraInfo = Config.RankSettings.PlayerNameKillMessages ? plugin.Localizer["k4.phrases.kill.extra", k4victim.PlayerName, 0] : null!;
 						}
 						ModifyPlayerPoints(k4attacker, CalculateDynamicPoints(k4attacker, k4victim, Config.PointSettings.Kill), "k4.phrases.kill", extraInfo);
@@ -383,11 +386,24 @@ namespace K4System
 				K4Player? k4assister = plugin.GetK4Player(@event.Assister);
 				if (k4assister?.IsValid == true && k4assister.IsPlayer && (Config.RankSettings.PointsForBots || k4victim.IsPlayer))
 				{
-					ModifyPlayerPoints(k4assister, Config.PointSettings.Assist, "k4.phrases.assist");
+					bool isFFAMode = Config.GeneralSettings.FFAMode;
+					bool victimIsEnemy = isFFAMode || (k4assister.Controller.Team != k4victim.Controller.Team);
 
-					if (@event.Assistedflash)
+					if (victimIsEnemy && !@event.Assistedflash)
+					{
+						ModifyPlayerPoints(k4assister, Config.PointSettings.Assist, "k4.phrases.assist");
+					}
+					else if (!victimIsEnemy && !@event.Assistedflash)
+					{
+						ModifyPlayerPoints(k4assister, Config.PointSettings.TeamAssist, "k4.phrases.teamassist");
+					}
+					else if (victimIsEnemy && @event.Assistedflash)
 					{
 						ModifyPlayerPoints(k4assister, Config.PointSettings.AssistFlash, "k4.phrases.assistflash");
+					}
+					else if (!victimIsEnemy && @event.Assistedflash)
+					{
+						ModifyPlayerPoints(k4assister, Config.PointSettings.TeamAssistFlash, "k4.phrases.teamassistflash");
 					}
 				}
 

--- a/K4-System/src/Plugin/PluginConfig.cs
+++ b/K4-System/src/Plugin/PluginConfig.cs
@@ -267,8 +267,14 @@ namespace K4System
 		[JsonPropertyName("assist")]
 		public int Assist { get; set; } = 5;
 
+		[JsonPropertyName("team-assist")]
+		public int TeamAssist { get; set; } = -5;
+
 		[JsonPropertyName("assist-flash")]
 		public int AssistFlash { get; set; } = 7;
+
+		[JsonPropertyName("team-assist-flash")]
+		public int TeamAssistFlash { get; set; } = -7;
 
 		[JsonPropertyName("round-win")]
 		public int RoundWin { get; set; } = 5;

--- a/K4-System/src/lang/en.json
+++ b/K4-System/src/lang/en.json
@@ -116,6 +116,8 @@
   "k4.phrases.godlike": "Godlike",
   "k4.phrases.assist": "Assist",
   "k4.phrases.assistflash": "Assist Flash",
+  "k4.phrases.teamassist": "Team Assist",
+  "k4.phrases.teamassistflash": "Team Assist Flash",
   "k4.phrases.shortyear": "y",
   "k4.phrases.shortmonth": "mo",
   "k4.phrases.shortday": "d",


### PR DESCRIPTION
Hello, the added checks in RankEvents.cs would fix the bug that getting assists on killed teammates (or getting a flash-assist on your teammate) would give a penalty instead of a reward. In case of FFA this check is of course not applied.

However, how do the language files work? I have only added it to the english file (since I do not speak the other languages). Do I need to add it to the other files? - if yes, should I use google translate for this?

This PR references bug #211 