### PR TITLE
fix suicide detection

### DIFF
--- a/K4-System/src/Module/Rank/RankEvents.cs
+++ b/K4-System/src/Module/Rank/RankEvents.cs
@@ -245,7 +245,7 @@ namespace K4System
 				{
 					k4victim.KillStreak = (0, DateTime.Now);
 
-					if (k4attacker is null || !k4attacker.IsValid || k4attacker.rankData is null)
+					if (k4attacker is null || !k4attacker.IsValid || k4attacker.rankData is null || k4attacker == k4victim)
 					{
 						ModifyPlayerPoints(k4victim, Config.PointSettings.Suicide, "k4.phrases.suicide");
 					}


### PR DESCRIPTION
suicide occurs when attacker == victim.

without this change, an actual player suicide results in them losing points as if they died to an attacker, rather than to suicide. 

Noticed this problem when using CCSPlayerController.ChangeTeam, which forces player suicide if they are alive. I had config set to lose 0 points for suicide, but player lost points. After this change, they do not lose points.
https://github.com/KitsuneLab-Development/K4-System/issues/208